### PR TITLE
Reduce the complexity of scrap_comment and adding line count test

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -43,6 +43,7 @@ fn main() {
         let wrapped_line = asm_file.read_instruction();
         match wrapped_line {
             None => break,
+            Some(ref s) if s.is_empty() => continue,
             Some(s) => println!("{}", s),
         }
     }

--- a/src/lib/filehandler.rs
+++ b/src/lib/filehandler.rs
@@ -23,38 +23,92 @@ impl FileHandler {
         return self.scrap_comment();
     }
 
-    /// Removes comments if found in a line, and skips
-    /// empty lines.
+    /// Removes comments if found in a line, and returns
+    /// an empty string if the line didn't conatin code
     fn scrap_comment(&mut self) -> Option<String> {
         let mut line = String::new();
 
-        loop {
-            match self.buf.read_line(&mut line) {
-                Ok(num) => {
-                    if num == 0 {
-                        return None;
-                    } else {
-                        line = line.split(".").nth(0).unwrap().trim().to_owned();
-
-                        if line.is_empty() {
-                            continue;
-                        }
-
-                        return Some(line);
+        match self.buf.read_line(&mut line) {
+            Ok(bytes_read) if bytes_read > 0 => {
+                match FileHandler::extract_code(&line) {
+                    Some(code_line) => {
+                        return Some(code_line);
                     }
-                }
-                Err(e) => {
-                    panic!(format!("An OS I/O error occured, this is really bad!, {}",
-                                   e.to_string()))
+                    None => Some(String::new()),
                 }
             }
-
+            Ok(_) => return None,
+            Err(e) => {
+                panic!(format!("An OS I/O error occured, this is really bad!, {}",
+                               e.to_string()))
+            }
         }
+    }
+
+    /// Extracts code in source file line
+    fn extract_code(line: &String) -> Option<String> {
+        let trimmed: String = line.split(".").nth(0).unwrap().trim().to_owned();
+
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        Some(trimmed)
     }
 }
 
-#[test]
-#[should_panic]
-fn test_file_opening() {
-    FileHandler::new("God Damn long file name that should never exit.asm".to_string());
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Use all your parent's imports
+    use regex::Regex;
+    use std::io::Read;
+    #[test]
+    #[should_panic]
+    fn test_file_opening() {
+        FileHandler::new("God Damn long file name that should never exit.asm".to_string());
+    }
+
+
+    #[test]
+    fn line_count_correct() {
+        let mut asm_file = FileHandler::new("src/tests/test1.asm".to_owned());
+        let mut line_count = 0;
+
+        // Regex reference: http://kbknapp.github.io/doapi-rs/docs/regex/index.html
+        // Escape all empty lines or comment lines
+        let empty_lines_regex = Regex::new(r"(?m)^\s*\n|^\s+").unwrap();
+        let comment_regex = Regex::new(r"(?m)\..+").unwrap();
+
+        let mut file_content: String = String::new();
+
+        match asm_file.buf.read_to_string(&mut file_content) {
+            Err(e) => println!("{}", e),
+            _ => (),
+        };
+
+        let empty_lines_cleared = empty_lines_regex.replace_all(&file_content, "");
+        let comments_cleared = comment_regex.replace_all(&empty_lines_cleared, "");
+
+        let lines = comments_cleared.split("\n")
+            .filter(|s: &&str| !s.is_empty())
+            .collect::<Vec<&str>>();
+
+        let mut asm_file = FileHandler::new("src/tests/test1.asm".to_owned());
+        loop {
+            let wrapped_line = asm_file.read_instruction();
+            match wrapped_line {
+                None => break,
+                Some(ref s) if s.is_empty() => continue,
+                Some(s) => {
+                    println!("{} {}", line_count, s);
+                    line_count += 1;
+                }
+            }
+        }
+        println!("{:?} --> {}", lines, lines.len());
+        // Check that the output from regex has the same number of lines as the
+        // output from the function
+        assert_eq!(line_count, lines.len());
+    }
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -7,6 +7,8 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
+extern crate regex;
+
 pub mod basic_types;
 pub mod pass_two;
 pub mod filehandler;

--- a/src/lib/pass_two/translator.rs
+++ b/src/lib/pass_two/translator.rs
@@ -1,10 +1,7 @@
-use basic_types::flags::*;
-use basic_types::instruction::{Instruction, AsmOperand};
+use basic_types::instruction::Instruction;
 use basic_types::operands::{OperandType, Value};
-use basic_types::formats::*;
 use basic_types::instruction_set::{self, AssemblyDef};
-use basic_types::unit_or_pair::UnitOrPair;
-use std::num;
+
 
 pub fn translate(instruction: &Instruction) -> Result<u32, &str> {
     //let f_vals = instruction.check_invalid_flags();   // TODO Report to RLS
@@ -37,9 +34,9 @@ pub fn translate(instruction: &Instruction) -> Result<u32, &str> {
 fn resolve_incomplete_operands(instruction: &Instruction) -> Result<Vec<u32>, &str> {
     // Convert immediate and indirect operands to a basic forms -> Raw
     let mut raws: Vec<u32> = Vec::new();
-    let opVec = instruction.unwrap_operands();
+    let op_vec = instruction.unwrap_operands();
 
-    for operand in &opVec {
+    for operand in &op_vec {
         let raw: Result<u32, &str> = match operand.val {
             Value::SignedInt(x) => Ok(x.abs() as u32),
             Value::Register(ref x) => Ok((*x as u8) as u32),

--- a/src/tests/test1.asm
+++ b/src/tests/test1.asm
@@ -13,6 +13,7 @@ ENDFIL	LDA	EOF	. insert end of file marker
 	JSUB	WRREC	. write EOF
 	LDL	RETARD	. get return address
 	RSUB
+. Whole line comment
 EOD	BYTE	C'EOF'
 THREE	WORD	3
 ZERO	WORD	0


### PR DESCRIPTION
- Line number unit test to ensure that no code lines are escaped
- Reduce nesting in `scrap_comment`